### PR TITLE
fix: grid styles

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -6,7 +6,7 @@ import { QUOTE, SITE_TITLE } from "@/consts";
 
 <div class="hero-bg hidden md:block h-screen hero-bg-animate absolute top-0"></div>
 <section
-  class="h-screen !z-[20] relative w-full grid grid-cols-1 grid-rows-1 sm:grid-cols-2 md:grid-cols-2 gap-4"
+  class="h-screen !z-[20] relative w-full grid grid-cols-1 grid-rows-1 sm:grid-cols-2 md:grid-cols-2 gap-4 items-center"
   id="hero"
 >
   <div class="grid place-items-center">


### PR DESCRIPTION
Aligned grid items to the center of the container.
![Captura de pantalla 2025-01-09 190655](https://github.com/user-attachments/assets/4e0b17c8-15ad-4080-9bc2-279ec2ccb07c)
